### PR TITLE
Mark Arrow as API dependency

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 dependencies {
     listOf(
         platform(libs.arrow.stack),
-        libs.arrow.core,
         libs.kotlinLogging,
         libs.kotlin.reflect,
         libs.kotlinx.coroutines.core,
@@ -16,7 +15,9 @@ dependencies {
     ).map {
         implementation(it)
     }
-    
+
+    api(libs.arrow.core)
+
     listOf(
         libs.kotest.runner,
         libs.kotest.assertions.core,

--- a/google-kms-grpc/build.gradle.kts
+++ b/google-kms-grpc/build.gradle.kts
@@ -14,10 +14,10 @@ plugins {
 
 dependencies {
     protobuf(libs.google.kms.protobuf)
+
     listOf(
         projects.core,
         platform(libs.arrow.stack),
-        libs.arrow.core,
         libs.grpc.protobuf,
         libs.grpc.stub,
         libs.grpc.stubKotlin,
@@ -26,6 +26,8 @@ dependencies {
     ).map {
         api(it)
     }
+
+    api(libs.arrow.core)
 
     listOf(
         libs.kotest.runner,

--- a/jwks/build.gradle.kts
+++ b/jwks/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
     listOf(
         projects.core,
         platform(libs.arrow.stack),
-        libs.arrow.core,
         libs.kotlin.reflect,
         libs.kotlinLogging,
         libs.kotlinx.coroutines.core,
@@ -18,6 +17,8 @@ dependencies {
     ).map {
         api(it)
     }
+
+    api(libs.arrow.core)
 
     listOf(
         libs.kotest.runner,


### PR DESCRIPTION
Since some of the public functions expose the Either type this library should mark Arrow as API, so users will automatically ~~get it~~ find a compatible one in their classpath.