### PR TITLE
chore: update arrow version to 2.0.0

### DIFF
--- a/build-logic/kotlin-convention/build.gradle.kts
+++ b/build-logic/kotlin-convention/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     implementation(libs.gradle.testlogger) // controls the version of the plugin used in the convention script plugin
     implementation(libs.gradle.nexusPublish) // controls the version of the plugin used in the convention script plugin
     implementation(libs.gradle.kotlin.jvm) // controls the version of the plugin used in the convention script plugin
+    implementation(libs.kotlin.gradle)
 }

--- a/build-logic/kotlin-convention/src/main/kotlin/buildtools/Catalog.kt
+++ b/build-logic/kotlin-convention/src/main/kotlin/buildtools/Catalog.kt
@@ -17,5 +17,5 @@ val Project.libsCatalog: VersionCatalog
 
 @Suppress("UnstableApiUsage")
 fun VersionCatalog.dependency(alias: String): Provider<MinimalExternalModuleDependency> {
-    return findDependency(alias).get()
+    return findLibrary(alias).get()
 }

--- a/build-logic/kotlin-convention/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/build-logic/kotlin-convention/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -49,8 +49,8 @@ tasks {
     withType<KotlinCompile>() {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict", "-Xopt-in=kotlin.RequiresOptIn")
-            languageVersion = "1.6"
-            apiVersion = "1.6"
+            languageVersion = "2.1"
+            apiVersion = "2.1"
             jvmTarget = "$jvmVersion"
         }
     }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         mavenLocal()

--- a/google-kms-grpc/src/main/kotlin/io/github/nefilim/kjwt/googlekms/GoogleKMS.kt
+++ b/google-kms-grpc/src/main/kotlin/io/github/nefilim/kjwt/googlekms/GoogleKMS.kt
@@ -1,8 +1,8 @@
 package io.github.nefilim.kjwt.googlekms
 
 import arrow.core.Either
-import arrow.core.computations.either
 import arrow.core.left
+import arrow.core.raise.either
 import com.google.cloud.kms.v1.CryptoKey
 import com.google.cloud.kms.v1.CryptoKeyVersion
 import com.google.cloud.kms.v1.KeyManagementServiceGrpcKt
@@ -21,6 +21,7 @@ import io.github.nefilim.kjwt.SignEncodedJWT
 import io.github.nefilim.kjwt.SignedJWT
 import io.github.nefilim.kjwt.jwtEncodeBytes
 import io.grpc.Metadata
+import jdk.javadoc.internal.doclets.toolkit.util.DocPath.parent
 import java.security.KeyFactory
 import java.security.MessageDigest
 import java.security.PublicKey

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-kotlin = "1.6.21"
+kotlin = "2.1.0"
 kotlinXCoroutines = "1.6.4"
-kotlinXSerialization = "1.4.1"
+kotlinXSerialization = "1.8.0"
 
 # third party
-arrow = "1.0.1"
+arrow = "2.0.0"
 google-kms = "0.94.0"
 gradle-github-release = "2.2.12"
 gradle-nexus-publish = "1.1.0"
@@ -17,8 +17,8 @@ grpc = "1.43.1"
 grpc-kotlin = "1.2.0"
 jib = "3.1.4"
 jib-extension = "0.1.0"
-kotest = "5.0.3"
-kotestExtensionsArrow = "1.2.1"
+kotest = "5.9.1"
+kotestExtensionsArrow = "2.0.0"
 kover = "0.4.4"
 kotlinLogging = "2.1.21"
 logback = "1.2.10"
@@ -28,6 +28,8 @@ protobuf = "3.19.1"
 slf4j = "1.7.4"
 
 [libraries]
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinXCoroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinXSerialization" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,4 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-enableFeaturePreview("VERSION_CATALOGS")
 
 rootProject.name = "kJWT"
 


### PR DESCRIPTION
I recently updated my ktor project to arrow 2.0.0 and realized that there was an error 

```
Caused by: java.lang.ClassNotFoundException: arrow.core.computations.either
```

as per this [issue](https://github.com/nefilim/kjwt/issues/35) I realized that that the lib needs and actual migration if we want to support arrow `2.0.0` so I did.

# Changelog
- I mostly replaced the old either dsl by the `raise` dsl
- I removed `ValidatedNel` as it does not exist enymore on Arrow, I replaced it by `EitherNel`
- I updated the kotlin version, and the gradle kotlin plugin
- updated kotest and kotlinx.serialization versions

# Checks
- I only run gradlew check and build passed with all tests in green
- I imported the project locally in my app and the login endpoint works again, no issue anymore 

Pd: If I'm missing any step I'll gladly add whatever is missing 🙏🏻 